### PR TITLE
Use multiline symbol to ensure newlines are preserved

### DIFF
--- a/templates/grafana-config.yaml
+++ b/templates/grafana-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  grafana.ini: >
+  grafana.ini: |-
     [paths]
     data = /var/lib/grafana
     logs = /var/log/grafana


### PR DESCRIPTION
@pb82 This fixes the grafana pod starting issue.
The grafana.ini was being formatted poorly without newlines, and thus not parsed correctly.
