### PR TITLE
Update & add templates to make grafana run with the oauth proxy in op…

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,12 +39,12 @@ func main() {
 	printVersion()
 
 	// namespace, err := k8sutil.GetWatchNamespace()
-	namespace := "grafana-tests"
+	namespace := ""
 	/*
-	if err != nil {
-		log.Error(err, "failed to get watch namespace")
-		os.Exit(1)
-	}
+		if err != nil {
+			log.Error(err, "failed to get watch namespace")
+			os.Exit(1)
+		}
 	*/
 
 	// Get a config to talk to the apiserver

--- a/templates/grafana-config.yaml
+++ b/templates/grafana-config.yaml
@@ -5,7 +5,7 @@ data:
     data = /var/lib/grafana
     logs = /var/log/grafana
     plugins = /var/lib/grafana/plugins
-    provisioning = /etc/grafana/conf/provisioning
+    provisioning = /etc/grafana/provisioning
 
     [log]
     # Either "console", "file", "syslog". Default is console and  file

--- a/templates/grafana-deployment.yaml
+++ b/templates/grafana-deployment.yaml
@@ -49,6 +49,24 @@ spec:
               name: grafana-logs
             - mountPath: /etc/grafana/
               name: {{ .GrafanaConfigMapName }}
+        - args:
+            - '-provider=openshift'
+            - '-https-address='
+            - '-http-address=0.0.0.0:3001'
+            - '-openshift-service-account={{ .GrafanaServiceAccountName }}'
+            - '-upstream=http://localhost:3000'
+            - '-cookie-secret=SECRET'
+            - '-skip-auth-regex=^/metrics'
+          image: 'registry.redhat.io/openshift3/oauth-proxy:v3.11.16'
+          imagePullPolicy: IfNotPresent
+          name: grafana-proxy
+          ports:
+            - containerPort: 3001
+              name: grafana-proxy
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/templates/grafana-route.yaml
+++ b/templates/grafana-route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: grafana
+spec:
+  port:
+    targetPort: grafana
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: grafana
+  wildcardPolicy: None

--- a/templates/grafana-service.yaml
+++ b/templates/grafana-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application-monitoring: "true"
+  name: grafana
+spec:
+  ports:
+  - name: grafana
+    port: 3001
+    protocol: TCP
+    targetPort: grafana-proxy
+  selector:
+    app: grafana

--- a/templates/grafana-serviceaccount.yaml
+++ b/templates/grafana-serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    # serviceaccounts.openshift.io/oauth-redirectreference.primary: >-
-    #  {"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-route"}}
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: >-
+     {"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-route"}}
   name: {{ .GrafanaServiceAccountName }}
   namespace: {{ .Namespace }}


### PR DESCRIPTION
…enshift

@pb82 This is a thrown together PR that includes the oauth-proxy, service and route in the grafana templates, just to get it working.

Before merging, I'd like to discuss a few things here so we know where best to take the operator.

* Should we be targeting raw kubernetes (not openshift)?
* Should the oauth proxy part of the deployment be optional?
* Should we go further than that, and allow the containers to include in the deployment to be specified in the `Grafana` CR? (similar to `Prometheus` CR)
* How best to solve the namespace watching? (related to #2) for `GrafanaDashboard` CRs